### PR TITLE
Add python-pip to list of packages being installed

### DIFF
--- a/scripts/marketplace_dl.sh
+++ b/scripts/marketplace_dl.sh
@@ -44,7 +44,7 @@ curl -s -L https://github.com/chef-customers/aws-signing-proxy/releases/download
 chmod 755 /usr/local/bin/aws-signing-proxy
 
 echo ">>> Installing other necessary packages"
-yum install -y perl perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https perl-Digest-SHA zip unzip
+yum install -y perl perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https perl-Digest-SHA zip unzip python-pip
 
 echo ">>> Installing monitoring tools"
 # Filebeat


### PR DESCRIPTION
Installing pip through yum ahead of time will eliminate the need for awslogs-agent-setup.py to download and install pip during provisioning.  This will also resolve the issue with the awslogs pip install process failing in environments that filter internet access through squid mentioned in https://github.com/chef-customers/aws_native_chef_server/issues/66