### PR TITLE
Install awscli from pip

### DIFF
--- a/scripts/install_admin_tools.sh
+++ b/scripts/install_admin_tools.sh
@@ -7,20 +7,6 @@ yum -y install lvm2 xfsprogs python-setuptools yum-utils git wget tuned sysstat 
 echo ">>> Installing things that Siebrand cares about"
 yum install -y bzip2 nfs-utils nmap screen tmpwatch tree zip
 
-echo ">>> Installing AWS cli"
-yum erase -y awscli python2-botocore python-s3transfer
-curl -sOL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
-unzip awscli-bundle.zip
-./awscli-bundle/install -i /usr/local/aws -b /bin/aws
-rm -rf awscli-bundle awscli-bundle.zip
-
-echo ">>> Installing AWS CloudFormation Helper Scripts"
-/usr/bin/easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-for i in `/bin/ls -1 /opt/aws/bin/`
-do
-    ln -sf /opt/aws/bin/$i /usr/bin/
-done
-
 echo ">>> Installing EPEL-based sysadmin tools"
 if yum repolist | grep -q ^epel
 then
@@ -29,3 +15,15 @@ else
     rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 fi
 yum install -y atop bash-completion-extras htop iftop nload tcping jq
+
+echo ">>> Installing AWS cli"
+yum install -y python2-pip
+pip install --upgrade pip
+pip install awscli --upgrade
+
+echo ">>> Installing AWS CloudFormation Helper Scripts"
+/usr/bin/easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+for i in `/bin/ls -1 /opt/aws/bin/`
+do
+    ln -sf /opt/aws/bin/$i /usr/bin/
+done


### PR DESCRIPTION
Installing from pip is more easily maintained than from the
AWS bundle. Had to move the installation of the package down
a little, because python2-pip depends on EPEL.